### PR TITLE
Add fixed top navigation bar

### DIFF
--- a/components/MainHeader.js
+++ b/components/MainHeader.js
@@ -162,7 +162,7 @@ export default function FixedHeader() {
   }, []);
 
   return (
-    <div id="header-container" className="relative h-[100svh] overflow-hidden z-0">
+    <div id="header-container" className="relative h-[calc(100svh-4rem)] overflow-hidden z-0">
       <div 
         id="header-background" 
         className="absolute inset-0 h-[200vh] bg-[url('/images/building-background.jpeg')] bg-cover bg-center z-5"

--- a/components/TopNav.js
+++ b/components/TopNav.js
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+
+export default function TopNav() {
+  return (
+    <nav className="fixed top-0 w-full h-16 bg-gray-900 text-white z-50">
+      <div className="max-w-screen-xl mx-auto h-full flex items-center justify-between px-4">
+        <Link href="/" className="font-semibold">Resume</Link>
+        <Link href="/login" className="font-semibold">Log In</Link>
+      </div>
+    </nav>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,13 @@
 import '../styles/globals.css';
+import TopNav from '../components/TopNav';
 
 export default function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <TopNav />
+      <div className="pt-16">
+        <Component {...pageProps} />
+      </div>
+    </>
+  );
 }

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,14 @@
+import Head from 'next/head';
+
+export default function Login() {
+  return (
+    <>
+      <Head>
+        <title>Log In</title>
+      </Head>
+      <div className="flex flex-col items-center justify-center min-h-[calc(100svh-4rem)]">
+        <h1 className="text-2xl font-semibold">Log In</h1>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add site-wide top navigation with Resume and Log In links
- adjust layout to include navigation and fix main header height
- add placeholder login page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68978e46ce3c832c852f7d4e612d25e0